### PR TITLE
Implement session management to only allow changes made by logged in users

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -746,6 +746,10 @@ const docTemplate = `{
                     "description": "Name is the name of the lobby.",
                     "type": "string"
                 },
+                "owner_account_id": {
+                    "description": "OwnerAccountId is the account ID of the lobby owner.",
+                    "type": "integer"
+                },
                 "owner_name": {
                     "description": "OwnerName is the name of the lobby owner.",
                     "type": "string"
@@ -775,6 +779,10 @@ const docTemplate = `{
                 "name": {
                     "description": "Name is the name of the lobby.",
                     "type": "string"
+                },
+                "owner_account_id": {
+                    "description": "OwnerAccountId is the account ID of the lobby owner.",
+                    "type": "integer"
                 },
                 "owner_name": {
                     "description": "OwnerName is the name of the lobby owner.",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -748,7 +748,7 @@ const docTemplate = `{
                 },
                 "owner_account_id": {
                     "description": "OwnerAccountId is the account ID of the lobby owner.",
-                    "type": "integer"
+                    "type": "string"
                 },
                 "owner_name": {
                     "description": "OwnerName is the name of the lobby owner.",
@@ -782,7 +782,7 @@ const docTemplate = `{
                 },
                 "owner_account_id": {
                     "description": "OwnerAccountId is the account ID of the lobby owner.",
-                    "type": "integer"
+                    "type": "string"
                 },
                 "owner_name": {
                     "description": "OwnerName is the name of the lobby owner.",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -84,6 +84,13 @@ const docTemplate = `{
                         "name": "account_id",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "session ID",
+                        "name": "session_id",
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -406,6 +406,111 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/sessions": {
+            "post": {
+                "description": "Create a new session for a user. Expires 12 hours from last interaction.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Create a new session",
+                "parameters": [
+                    {
+                        "description": "User ID",
+                        "name": "account_id",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/auth.Session"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {}
+                    }
+                }
+            }
+        },
+        "/sessions/{id}": {
+            "get": {
+                "description": "Get a session by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Get a session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/auth.Session"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {}
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete a session by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Delete a session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {}
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -524,6 +629,23 @@ const docTemplate = `{
                 },
                 "password": {
                     "description": "The password for the account to be created",
+                    "type": "string"
+                }
+            }
+        },
+        "auth.Session": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "id": {
                     "type": "string"
                 }
             }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -630,6 +630,10 @@ const docTemplate = `{
                 "password": {
                     "description": "The password for the account to be created",
                     "type": "string"
+                },
+                "session_id": {
+                    "description": "A valid session ID for the account (so we know they are signed in)",
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -739,7 +739,7 @@
                 },
                 "owner_account_id": {
                     "description": "OwnerAccountId is the account ID of the lobby owner.",
-                    "type": "integer"
+                    "type": "string"
                 },
                 "owner_name": {
                     "description": "OwnerName is the name of the lobby owner.",
@@ -773,7 +773,7 @@
                 },
                 "owner_account_id": {
                     "description": "OwnerAccountId is the account ID of the lobby owner.",
-                    "type": "integer"
+                    "type": "string"
                 },
                 "owner_name": {
                     "description": "OwnerName is the name of the lobby owner.",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -75,6 +75,13 @@
                         "name": "account_id",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "session ID",
+                        "name": "session_id",
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -621,6 +621,10 @@
                 "password": {
                     "description": "The password for the account to be created",
                     "type": "string"
+                },
+                "session_id": {
+                    "description": "A valid session ID for the account (so we know they are signed in)",
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -397,6 +397,111 @@
                     }
                 }
             }
+        },
+        "/sessions": {
+            "post": {
+                "description": "Create a new session for a user. Expires 12 hours from last interaction.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Create a new session",
+                "parameters": [
+                    {
+                        "description": "User ID",
+                        "name": "account_id",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/auth.Session"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {}
+                    }
+                }
+            }
+        },
+        "/sessions/{id}": {
+            "get": {
+                "description": "Get a session by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Get a session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/auth.Session"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {}
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete a session by its ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Delete a session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {}
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -515,6 +620,23 @@
                 },
                 "password": {
                     "description": "The password for the account to be created",
+                    "type": "string"
+                }
+            }
+        },
+        "auth.Session": {
+            "type": "object",
+            "properties": {
+                "account_id": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -737,6 +737,10 @@
                     "description": "Name is the name of the lobby.",
                     "type": "string"
                 },
+                "owner_account_id": {
+                    "description": "OwnerAccountId is the account ID of the lobby owner.",
+                    "type": "integer"
+                },
                 "owner_name": {
                     "description": "OwnerName is the name of the lobby owner.",
                     "type": "string"
@@ -766,6 +770,10 @@
                 "name": {
                     "description": "Name is the name of the lobby.",
                     "type": "string"
+                },
+                "owner_account_id": {
+                    "description": "OwnerAccountId is the account ID of the lobby owner.",
+                    "type": "integer"
                 },
                 "owner_name": {
                     "description": "OwnerName is the name of the lobby owner.",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -165,7 +165,7 @@ definitions:
         type: string
       owner_account_id:
         description: OwnerAccountId is the account ID of the lobby owner.
-        type: integer
+        type: string
       owner_name:
         description: OwnerName is the name of the lobby owner.
         type: string
@@ -190,7 +190,7 @@ definitions:
         type: string
       owner_account_id:
         description: OwnerAccountId is the account ID of the lobby owner.
-        type: integer
+        type: string
       owner_name:
         description: OwnerName is the name of the lobby owner.
         type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -82,6 +82,17 @@ definitions:
         description: The password for the account to be created
         type: string
     type: object
+  auth.Session:
+    properties:
+      account_id:
+        type: integer
+      created_at:
+        type: string
+      expires_at:
+        type: string
+      id:
+        type: string
+    type: object
   game.CreateGameArgs:
     description: Structure for the game creation request payload.
     properties:
@@ -457,4 +468,74 @@ paths:
       summary: Updates a lobby
       tags:
       - lobby
+  /sessions:
+    post:
+      consumes:
+      - application/json
+      description: Create a new session for a user. Expires 12 hours from last interaction.
+      parameters:
+      - description: User ID
+        in: body
+        name: account_id
+        required: true
+        schema:
+          type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/auth.Session'
+        "400":
+          description: Bad Request
+          schema: {}
+      summary: Create a new session
+      tags:
+      - sessions
+  /sessions/{id}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a session by its ID
+      parameters:
+      - description: Session ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema: {}
+      summary: Delete a session
+      tags:
+      - sessions
+    get:
+      consumes:
+      - application/json
+      description: Get a session by its ID
+      parameters:
+      - description: Session ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/auth.Session'
+        "404":
+          description: Not Found
+          schema: {}
+      summary: Get a session
+      tags:
+      - sessions
 swagger: "2.0"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -81,6 +81,10 @@ definitions:
       password:
         description: The password for the account to be created
         type: string
+      session_id:
+        description: A valid session ID for the account (so we know they are signed
+          in)
+        type: integer
     type: object
   auth.Session:
     properties:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -163,6 +163,9 @@ definitions:
       name:
         description: Name is the name of the lobby.
         type: string
+      owner_account_id:
+        description: OwnerAccountId is the account ID of the lobby owner.
+        type: integer
       owner_name:
         description: OwnerName is the name of the lobby owner.
         type: string
@@ -185,6 +188,9 @@ definitions:
       name:
         description: Name is the name of the lobby.
         type: string
+      owner_account_id:
+        description: OwnerAccountId is the account ID of the lobby owner.
+        type: integer
       owner_name:
         description: OwnerName is the name of the lobby owner.
         type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -251,6 +251,11 @@ paths:
         name: account_id
         required: true
         type: integer
+      - description: session ID
+        in: query
+        name: session_id
+        required: true
+        type: integer
       produces:
       - application/json
       responses:

--- a/internal/account/account_handler.go
+++ b/internal/account/account_handler.go
@@ -4,10 +4,12 @@ import (
 	"net/http"
 
 	"github.com/jmoiron/sqlx"
+
+	auth "github.com/justinfarrelldev/open-ctp-server/internal/auth"
 )
 
-func CreateAccountHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB) {
-	if err := CreateAccount(w, r, db); err != nil {
+func CreateAccountHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth.SessionStore) {
+	if _, err := CreateAccount(w, r, db, store); err != nil {
 		// Handle the error, e.g., log it and send an appropriate response to the client
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/account/account_handler.go
+++ b/internal/account/account_handler.go
@@ -24,8 +24,8 @@ func GetAccountHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB) {
 	}
 }
 
-func UpdateAccountHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB) {
-	if err := UpdateAccount(w, r, db); err != nil {
+func UpdateAccountHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth.SessionStore) {
+	if err := UpdateAccount(w, r, db, store); err != nil {
 		// Handle the error, e.g., log it and send an appropriate response to the client
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/account/account_handler.go
+++ b/internal/account/account_handler.go
@@ -16,8 +16,8 @@ func CreateAccountHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB, s
 	}
 }
 
-func GetAccountHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB) {
-	if err := GetAccount(w, r, db); err != nil {
+func GetAccountHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth.SessionStore) {
+	if err := GetAccount(w, r, db, store); err != nil {
 		// Handle the error, e.g., log it and send an appropriate response to the client
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/account/account_handler_test.go
+++ b/internal/account/account_handler_test.go
@@ -65,7 +65,7 @@ func TestCreateAccountHandler_InvalidMethod(t *testing.T) {
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 	store := auth.NewSessionStore(sqlxDB)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		CreateAccount(w, r, sqlxDB, store)
+		CreateAccountHandler(w, r, sqlxDB, store)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -96,7 +96,7 @@ func TestCreateAccountHandler_DecodeError(t *testing.T) {
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 	store := auth.NewSessionStore(sqlxDB)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		CreateAccount(w, r, sqlxDB, store)
+		CreateAccountHandler(w, r, sqlxDB, store)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -127,7 +127,7 @@ func TestCreateAccountHandler_EmailRequired(t *testing.T) {
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 	store := auth.NewSessionStore(sqlxDB)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		CreateAccount(w, r, sqlxDB, store)
+		CreateAccountHandler(w, r, sqlxDB, store)
 	})
 
 	handler.ServeHTTP(rr, req)

--- a/internal/account/account_handler_test.go
+++ b/internal/account/account_handler_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"
+
+	auth "github.com/justinfarrelldev/open-ctp-server/internal/auth"
 )
 
 // func TestCreateAccountHandler_Success(t *testing.T) {
@@ -61,8 +63,9 @@ func TestCreateAccountHandler_InvalidMethod(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	store := auth.NewSessionStore(sqlxDB)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		CreateAccountHandler(w, r, sqlxDB)
+		CreateAccount(w, r, sqlxDB, store)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -91,8 +94,9 @@ func TestCreateAccountHandler_DecodeError(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	store := auth.NewSessionStore(sqlxDB)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		CreateAccountHandler(w, r, sqlxDB)
+		CreateAccount(w, r, sqlxDB, store)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -121,8 +125,9 @@ func TestCreateAccountHandler_EmailRequired(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	store := auth.NewSessionStore(sqlxDB)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		CreateAccountHandler(w, r, sqlxDB)
+		CreateAccount(w, r, sqlxDB, store)
 	})
 
 	handler.ServeHTTP(rr, req)

--- a/internal/account/create_account.go
+++ b/internal/account/create_account.go
@@ -149,19 +149,11 @@ func CreateAccount(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *a
 }
 
 func storeAccount(account *Account, db *sqlx.DB) (accountId *int, err error) {
-	result, err := db.Query("INSERT INTO account (name, info, location, email, experience_level) VALUES ($1, $2, $3, $4, $5)", account.Name, account.Info, account.Location, account.Email, account.ExperienceLevel)
+	var id int
+	err = db.QueryRow("INSERT INTO account (name, info, location, email, experience_level) VALUES ($1, $2, $3, $4, $5) RETURNING id", account.Name, account.Info, account.Location, account.Email, account.ExperienceLevel).Scan(&id)
 	if err != nil {
 		return nil, errors.New("an error occurred while inserting an account into the database: " + err.Error())
 	}
 
-	var id *int
-	if result.Next() {
-		err = result.Scan(&id)
-		if err != nil {
-			return nil, errors.New("an error occurred while retrieving the account ID: " + err.Error())
-		}
-	}
-
-	defer result.Close()
-	return id, nil
+	return &id, nil
 }

--- a/internal/account/create_account_test.go
+++ b/internal/account/create_account_test.go
@@ -123,7 +123,6 @@ func TestCreateAccount_PasswordRequired(t *testing.T) {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusBadRequest)
 	}
 }
-
 func TestCreateAccount_Success(t *testing.T) {
 	account := CreateAccountArgs{
 		Account: Account{
@@ -163,6 +162,10 @@ func TestCreateAccount_Success(t *testing.T) {
 	mock.ExpectQuery("INSERT INTO passwords \\(account_email, hash, salt\\) VALUES \\(\\$1, \\$2, \\$3\\)").
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+
+	mock.ExpectExec("INSERT INTO sessions \\(id, account_id, created_at, expires_at\\) VALUES \\(\\?, \\?, \\?, \\?\\)").
+		WithArgs(sqlmock.AnyArg(), 1, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	mockStore := &auth.SessionStore{
 		DB: sqlxDB,

--- a/internal/account/create_account_test.go
+++ b/internal/account/create_account_test.go
@@ -164,7 +164,9 @@ func TestCreateAccount_Success(t *testing.T) {
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
 
-	mockStore := &auth.SessionStore{}
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
 
 	_, err = CreateAccount(rr, req, sqlxDB, mockStore)
 	if err != nil {

--- a/internal/account/get_account.go
+++ b/internal/account/get_account.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/jmoiron/sqlx"
+	auth "github.com/justinfarrelldev/open-ctp-server/internal/auth"
 )
 
 // GetAccountArgs represents the expected structure of the request body for getting an account.
@@ -17,6 +18,8 @@ import (
 type GetAccountArgs struct {
 	// The account ID for the account that will be retrieved.
 	AccountId int64 `json:"account_id"`
+	// A valid session ID for the account (so we know they are signed in)
+	SessionId int64 `json:"session_id"`
 }
 
 // GetAccount gets an account by the account ID.
@@ -27,6 +30,7 @@ type GetAccountArgs struct {
 // @Accept json
 // @Produce json
 // @Param account_id query int true "account ID"
+// @Param session_id query int true "session ID"
 //
 // @Success 200 {object} account.Account "Account successfully retrieved"
 //
@@ -34,7 +38,7 @@ type GetAccountArgs struct {
 // @Failure 403 {object} error "Forbidden"
 // @Failure 500 {object} error "Internal Server Error"
 // @Router /account/get_account [get]
-func GetAccount(w http.ResponseWriter, r *http.Request, db *sqlx.DB) error {
+func GetAccount(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth.SessionStore) error {
 	if r.Method != "GET" {
 		return errors.New("invalid request; request must be a GET request")
 	}
@@ -48,6 +52,32 @@ func GetAccount(w http.ResponseWriter, r *http.Request, db *sqlx.DB) error {
 	accountId, err := strconv.ParseInt(accountIdStr, 10, 64)
 	if err != nil {
 		return errors.New("invalid account_id")
+	}
+
+	sessionIdStr := queryParams.Get("session_id")
+	if sessionIdStr == "" {
+		return errors.New("session_id is required")
+	}
+
+	sessionId, err := strconv.ParseInt(sessionIdStr, 10, 64)
+	if err != nil {
+		return errors.New("invalid session_id")
+	}
+
+	session, err := store.GetSession(strconv.FormatInt(sessionId, 10))
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return errors.New("an error occurred while retrieving the session: " + err.Error())
+	}
+
+	if session == nil {
+		w.WriteHeader(http.StatusForbidden)
+		return errors.New("session not found")
+	}
+
+	if session.IsExpired() {
+		w.WriteHeader(http.StatusForbidden)
+		return errors.New("session has expired")
 	}
 
 	var (

--- a/internal/account/update_account.go
+++ b/internal/account/update_account.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strconv"
 
 	"github.com/jmoiron/sqlx"
 	auth "github.com/justinfarrelldev/open-ctp-server/internal/auth"
@@ -65,7 +66,7 @@ func UpdateAccount(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *a
 		return errors.New("a valid session_id must be specified")
 	}
 
-	session, err := store.GetSession(string(*args.SessionId))
+	session, err := store.GetSession(strconv.FormatInt(*args.SessionId, 10))
 
 	if err != nil {
 

--- a/internal/account/update_account_test.go
+++ b/internal/account/update_account_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"
@@ -188,9 +189,13 @@ func TestUpdateAccount_Success(t *testing.T) {
 	storedHash := base64.StdEncoding.EncodeToString(hashSalt.Hash)
 	storedSalt := base64.StdEncoding.EncodeToString(hashSalt.Salt)
 
+	createdAt := time.Now()
+	expiresAt := time.Now().Add(6 * time.Hour)
+
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM sessions WHERE id = $1")).
 		WithArgs(sessionID).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "account_id"}).AddRow(sessionID, accountID))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "account_id", "created_at", "expires_at"}).
+			AddRow(sessionID, accountID, createdAt, expiresAt))
 
 	mock.ExpectQuery("SELECT hash, salt FROM passwords WHERE id = \\$1").
 		WithArgs(accountID).
@@ -260,9 +265,13 @@ func TestUpdateAccount_MissingPassword(t *testing.T) {
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 
+	createdAt := time.Now()
+	expiresAt := time.Now().Add(6 * time.Hour)
+
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM sessions WHERE id = $1")).
 		WithArgs(sessionID).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "account_id"}).AddRow(sessionID, accountID))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "account_id", "created_at", "expires_at"}).
+			AddRow(sessionID, accountID, createdAt, expiresAt))
 
 	mockStore := &auth.SessionStore{
 		DB: sqlxDB,
@@ -318,9 +327,13 @@ func TestUpdateAccount_MissingAccount(t *testing.T) {
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 
+	createdAt := time.Now()
+	expiresAt := time.Now().Add(6 * time.Hour)
+
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM sessions WHERE id = $1")).
 		WithArgs(sessionID).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "account_id"}).AddRow(sessionID, accountID))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "account_id", "created_at", "expires_at"}).
+			AddRow(sessionID, accountID, createdAt, expiresAt))
 
 	mockStore := &auth.SessionStore{
 		DB: sqlxDB,

--- a/internal/account/update_account_test.go
+++ b/internal/account/update_account_test.go
@@ -29,8 +29,13 @@ func TestUpdateAccount_InvalidMethod(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := UpdateAccount(w, r, sqlxDB)
+		err := UpdateAccount(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -62,8 +67,13 @@ func TestUpdateAccount_DecodeError(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := UpdateAccount(w, r, sqlxDB)
+		err := UpdateAccount(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -101,8 +111,13 @@ func TestUpdateAccount_MissingAccountID(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := UpdateAccount(w, r, sqlxDB)
+		err := UpdateAccount(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -128,6 +143,7 @@ func TestUpdateAccount_Success(t *testing.T) {
 	defer db.Close()
 
 	accountID := int64(1)
+	sessionID := int64(1)
 	password := "password123"
 	name := "Updated Name"
 	info := "Updated Info"
@@ -145,6 +161,7 @@ func TestUpdateAccount_Success(t *testing.T) {
 			Email:           &email,
 			ExperienceLevel: (*ExperienceLevel)(&experienceLevel),
 		},
+		SessionId: &sessionID,
 	}
 
 	body, _ := json.Marshal(updateArgs)
@@ -173,8 +190,12 @@ func TestUpdateAccount_Success(t *testing.T) {
 		WithArgs(name, info, location, email, experienceLevel, accountID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := UpdateAccount(w, r, sqlxDB)
+		err := UpdateAccount(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -204,6 +225,7 @@ func TestUpdateAccount_MissingPassword(t *testing.T) {
 	defer db.Close()
 
 	accountID := int64(1)
+	sessionID := int64(1)
 	name := "Updated Name"
 
 	updateArgs := UpdateAccountArgs{
@@ -211,6 +233,7 @@ func TestUpdateAccount_MissingPassword(t *testing.T) {
 		Account: &AccountParam{
 			Name: &name,
 		},
+		SessionId: &sessionID,
 	}
 
 	body, _ := json.Marshal(updateArgs)
@@ -221,8 +244,13 @@ func TestUpdateAccount_MissingPassword(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := UpdateAccount(w, r, sqlxDB)
+		err := UpdateAccount(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -248,11 +276,13 @@ func TestUpdateAccount_MissingAccount(t *testing.T) {
 	defer db.Close()
 
 	accountID := int64(1)
+	sessionID := int64(1)
 	password := "password123"
 
 	updateArgs := UpdateAccountArgs{
 		AccountId: &accountID,
 		Password:  &password,
+		SessionId: &sessionID,
 	}
 
 	body, _ := json.Marshal(updateArgs)
@@ -263,8 +293,13 @@ func TestUpdateAccount_MissingAccount(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := UpdateAccount(w, r, sqlxDB)
+		err := UpdateAccount(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/internal/auth/sessions.go
+++ b/internal/auth/sessions.go
@@ -1,0 +1,112 @@
+package auth
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// Session represents a user session
+type Session struct {
+	ID        string    `db:"id" json:"id"`
+	AccountID int       `db:"account_id" json:"account_id"`
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
+	ExpiresAt time.Time `db:"expires_at" json:"expires_at"`
+}
+
+// SessionStore handles session-related database operations
+type SessionStore struct {
+	db *sqlx.DB
+}
+
+// NewSessionStore creates a new SessionStore
+func NewSessionStore(db *sqlx.DB) *SessionStore {
+	return &SessionStore{db: db}
+}
+
+// CreateSession creates a new session for a user
+// @Summary Create a new session
+// @Description Create a new session for a user. Expires 12 hours from last interaction.
+// @Tags sessions
+// @Accept json
+// @Produce json
+// @Param account_id body int true "User ID"
+// @Success 200 {object} Session
+// @Failure 400 {object} error
+// @Router /sessions [post]
+func (s *SessionStore) CreateSession(accountID int) (*Session, error) {
+	sessionID, err := generateSessionID()
+	if err != nil {
+		return nil, err
+	}
+
+	session := &Session{
+		ID:        sessionID,
+		AccountID: accountID,
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(12 * time.Hour), // Session expires in 12 hours
+	}
+
+	query := `INSERT INTO sessions (id, account_id, created_at, expires_at) VALUES (:id, :account_id, :created_at, :expires_at)`
+	_, err = s.db.NamedExec(query, session)
+	if err != nil {
+		return nil, err
+	}
+
+	return session, nil
+}
+
+// GetSession retrieves a session by its ID
+// @Summary Get a session
+// @Description Get a session by its ID
+// @Tags sessions
+// @Accept json
+// @Produce json
+// @Param id path string true "Session ID"
+// @Success 200 {object} Session
+// @Failure 404 {object} error
+// @Router /sessions/{id} [get]
+func (s *SessionStore) GetSession(sessionID string) (*Session, error) {
+	var session Session
+	query := `SELECT * FROM sessions WHERE id = $1`
+	err := s.db.Get(&session, query, sessionID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &session, nil
+}
+
+// DeleteSession deletes a session by its ID. Should not be exposed to end users via any API endpoints.
+// This should instead be used to invalidate any sessions when, for example, a user logs out or an account is deleted.
+// @Summary Delete a session
+// @Description Delete a session by its ID
+// @Tags sessions
+// @Accept json
+// @Produce json
+// @Param id path string true "Session ID"
+// @Success 204
+// @Failure 404 {object} error
+// @Router /sessions/{id} [delete]
+func (s *SessionStore) DeleteSession(sessionID string) error {
+	query := `DELETE FROM sessions WHERE id = $1`
+	_, err := s.db.Exec(query, sessionID)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// generateSessionID generates a unique session ID
+func generateSessionID() (string, error) {
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}

--- a/internal/auth/sessions.go
+++ b/internal/auth/sessions.go
@@ -104,7 +104,7 @@ func (s *SessionStore) DeleteSession(sessionID string) error {
 
 // generateSessionID generates a unique session ID
 func generateSessionID() (string, error) {
-	bytes := make([]byte, 16)
+	bytes := make([]byte, 64)
 	if _, err := rand.Read(bytes); err != nil {
 		return "", err
 	}

--- a/internal/auth/sessions.go
+++ b/internal/auth/sessions.go
@@ -131,3 +131,13 @@ func generateSessionID() (string, error) {
 	}
 	return hex.EncodeToString(bytes), nil
 }
+
+// IsExpired checks if the session has expired
+// @Summary Check if session is expired
+// @Description Returns true if the session has expired, false otherwise
+// @Tags sessions
+// @Accept json
+// @Produce json
+func (s *Session) IsExpired() bool {
+	return time.Now().After(s.ExpiresAt)
+}

--- a/internal/auth/sessions_test.go
+++ b/internal/auth/sessions_test.go
@@ -176,3 +176,43 @@ func TestDeleteSession_Error(t *testing.T) {
 		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
 }
+
+func TestIsExpired(t *testing.T) {
+	tests := []struct {
+		name      string
+		expiresAt time.Time
+		want      bool
+	}{
+		{
+			name:      "not expired - future time",
+			expiresAt: time.Now().Add(1 * time.Hour),
+			want:      false,
+		},
+		{
+			name:      "expired - past time",
+			expiresAt: time.Now().Add(-1 * time.Hour),
+			want:      true,
+		},
+		{
+			name:      "expired - current time",
+			expiresAt: time.Now(),
+			want:      true,
+		},
+		{
+			name:      "not expired - far future",
+			expiresAt: time.Now().Add(24 * time.Hour),
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := &Session{
+				ExpiresAt: tt.expiresAt,
+			}
+			if got := session.IsExpired(); got != tt.want {
+				t.Errorf("Session.IsExpired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/auth/sessions_test.go
+++ b/internal/auth/sessions_test.go
@@ -1,0 +1,178 @@
+package auth
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+)
+
+func TestCreateSession_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	store := NewSessionStore(sqlxDB)
+
+	accountID := 1
+	mock.ExpectExec("INSERT INTO sessions").
+		WithArgs(sqlmock.AnyArg(), accountID, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	session, err := store.CreateSession(accountID)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if session.AccountID != accountID {
+		t.Errorf("expected account ID %d, got %d", accountID, session.AccountID)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+func TestCreateSession_Error(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	store := NewSessionStore(sqlxDB)
+
+	accountID := 1
+	mock.ExpectExec("INSERT INTO sessions").
+		WithArgs(sqlmock.AnyArg(), accountID, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnError(sql.ErrConnDone)
+
+	_, err = store.CreateSession(accountID)
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+func TestGetSession_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	store := NewSessionStore(sqlxDB)
+
+	sessionID := "test-session-id"
+	accountID := 1
+	createdAt := time.Now()
+	expiresAt := createdAt.Add(12 * time.Hour)
+
+	rows := sqlmock.NewRows([]string{"id", "account_id", "created_at", "expires_at"}).
+		AddRow(sessionID, accountID, createdAt, expiresAt)
+	mock.ExpectQuery("SELECT \\* FROM sessions WHERE id = \\$1").
+		WithArgs(sessionID).
+		WillReturnRows(rows)
+
+	session, err := store.GetSession(sessionID)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if session.ID != sessionID {
+		t.Errorf("expected session ID %s, got %s", sessionID, session.ID)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+func TestGetSession_NotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	store := NewSessionStore(sqlxDB)
+
+	sessionID := "non-existent-session-id"
+	mock.ExpectQuery("SELECT \\* FROM sessions WHERE id = \\$1").
+		WithArgs(sessionID).
+		WillReturnError(sql.ErrNoRows)
+
+	session, err := store.GetSession(sessionID)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if session != nil {
+		t.Errorf("expected nil session, got %v", session)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+func TestDeleteSession_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	store := NewSessionStore(sqlxDB)
+
+	sessionID := "test-session-id"
+	mock.ExpectExec("DELETE FROM sessions WHERE id = \\$1").
+		WithArgs(sessionID).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = store.DeleteSession(sessionID)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+func TestDeleteSession_Error(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close()
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	store := NewSessionStore(sqlxDB)
+
+	sessionID := "test-session-id"
+	mock.ExpectExec("DELETE FROM sessions WHERE id = \\$1").
+		WithArgs(sessionID).
+		WillReturnError(sql.ErrConnDone)
+
+	err = store.DeleteSession(sessionID)
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}

--- a/internal/lobby/create_lobby.go
+++ b/internal/lobby/create_lobby.go
@@ -88,8 +88,8 @@ func CreateLobby(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *aut
 
 func storeLobby(lobby *Lobby, db *sqlx.DB) error {
 	result, err := db.Query(
-		"INSERT INTO lobby (name, owner_name, is_closed, is_muted, is_public) VALUES ($1, $2, $3, $4, $5)",
-		lobby.Name, lobby.OwnerName, lobby.IsClosed, lobby.IsMuted, lobby.IsPublic,
+		"INSERT INTO lobby (name, owner_name, owner_account_id, is_closed, is_muted, is_public) VALUES ($1, $2, $3, $4, $5, $6)",
+		lobby.Name, lobby.OwnerName, lobby.OwnerAccountId, lobby.IsClosed, lobby.IsMuted, lobby.IsPublic,
 	)
 	if err != nil {
 		return errors.New("an error occurred while inserting a lobby into the database: " + err.Error())

--- a/internal/lobby/create_lobby.go
+++ b/internal/lobby/create_lobby.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/justinfarrelldev/open-ctp-server/internal/auth"
 )
 
 // CreateLobbyArgs represents the expected structure of the request body for creating a lobby for use within the server.
@@ -37,7 +38,7 @@ const ERROR_PASSWORD_REQUIRED_BUT_NO_PASSWORD = "password is required"
 // @Failure 403 {object} error "Forbidden"
 // @Failure 500 {object} error "Internal Server Error"
 // @Router /lobby/create_lobby [post]
-func CreateLobby(w http.ResponseWriter, r *http.Request, db *sqlx.DB) error {
+func CreateLobby(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth.SessionStore) error {
 
 	if r.Method != "POST" {
 		return errors.New("invalid request; request must be a POST request")

--- a/internal/lobby/create_lobby.go
+++ b/internal/lobby/create_lobby.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -58,6 +59,11 @@ func CreateLobby(w http.ResponseWriter, r *http.Request, db *sqlx.DB) error {
 		w.WriteHeader(http.StatusBadRequest)
 
 		return errors.New(ERROR_PASSWORD_REQUIRED_BUT_NO_PASSWORD)
+	}
+
+	if _, err := strconv.ParseInt(lobby.Lobby.OwnerAccountId, 10, 64); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return errors.New("OwnerAccountId must be a valid number")
 	}
 
 	if len(lobby.Password) < 6 {

--- a/internal/lobby/create_lobby_test.go
+++ b/internal/lobby/create_lobby_test.go
@@ -1,6 +1,8 @@
 package lobby
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -19,18 +21,25 @@ func TestCreateLobby_Success(t *testing.T) {
 	defer db.Close()
 
 	lobby := Lobby{
-		Name:      "Test Lobby",
-		OwnerName: "Owner",
-		IsClosed:  false,
-		IsMuted:   false,
-		IsPublic:  true,
+		Name:           "Test Lobby",
+		OwnerName:      "Owner",
+		OwnerAccountId: "1",
+		IsClosed:       false,
+		IsMuted:        false,
+		IsPublic:       true,
 	}
 
-	mock.ExpectQuery("INSERT INTO lobby \\(name, owner_name, is_closed, is_muted, is_public\\) VALUES \\(\\$1, \\$2, \\$3, \\$4, \\$5\\)").
-		WithArgs(lobby.Name, lobby.OwnerName, lobby.IsClosed, lobby.IsMuted, lobby.IsPublic).
+	mock.ExpectQuery("INSERT INTO lobby \\(name, owner_name, owner_account_id, is_closed, is_muted, is_public\\) VALUES \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6\\)").
+		WithArgs(lobby.Name, lobby.OwnerName, lobby.OwnerAccountId, lobby.IsClosed, lobby.IsMuted, lobby.IsPublic).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
 
-	req, err := http.NewRequest("POST", "/lobby/create_lobby", strings.NewReader(`{"lobby": {"name": "Test Lobby", "owner_name": "Owner", "is_closed": false, "is_muted": false, "is_public": true}, "password": "password123"}`))
+	lobbyBytes, err := json.Marshal(lobby)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lobbyJSON := fmt.Sprintf(`{"lobby": %s, "password": "password123"}`, string(lobbyBytes))
+
+	req, err := http.NewRequest("POST", "/lobby/create_lobby", strings.NewReader(lobbyJSON))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/lobby/create_lobby_test.go
+++ b/internal/lobby/create_lobby_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"
+	auth "github.com/justinfarrelldev/open-ctp-server/internal/auth"
 )
 
 func TestCreateLobby_Success(t *testing.T) {
@@ -36,8 +37,13 @@ func TestCreateLobby_Success(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := CreateLobby(w, r, sqlxDB)
+		err := CreateLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -64,8 +70,13 @@ func TestCreateLobby_InvalidMethod(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := CreateLobby(w, r, sqlxDB)
+		err := CreateLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -97,8 +108,13 @@ func TestCreateLobby_DecodeError(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := CreateLobby(w, r, sqlxDB)
+		err := CreateLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -130,8 +146,13 @@ func TestCreateLobby_PasswordTooShort(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := CreateLobby(w, r, sqlxDB)
+		err := CreateLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
@@ -163,8 +184,13 @@ func TestCreateLobby_PasswordRequired(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := CreateLobby(w, r, sqlxDB)
+		err := CreateLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}

--- a/internal/lobby/create_lobby_test.go
+++ b/internal/lobby/create_lobby_test.go
@@ -148,7 +148,22 @@ func TestCreateLobby_PasswordTooShort(t *testing.T) {
 	}
 	defer db.Close()
 
-	req, err := http.NewRequest("POST", "/lobby/create_lobby", strings.NewReader(`{"lobby": {"name": "Test Lobby", "owner_name": "Owner", "is_closed": false, "is_muted": false, "is_public": true}, "password": "123"}`))
+	lobby := Lobby{
+		Name:           "Test Lobby",
+		OwnerName:      "Owner",
+		OwnerAccountId: "1",
+		IsClosed:       false,
+		IsMuted:        false,
+		IsPublic:       true,
+	}
+
+	lobbyBytes, err := json.Marshal(lobby)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lobbyJSON := fmt.Sprintf(`{"lobby": %s, "password": "123"}`, string(lobbyBytes))
+
+	req, err := http.NewRequest("POST", "/lobby/create_lobby", strings.NewReader(lobbyJSON))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/lobby/delete_lobby.go
+++ b/internal/lobby/delete_lobby.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/justinfarrelldev/open-ctp-server/internal/auth"
 )
 
 // DeleteLobbyArgs represents the expected structure of the request body for deleting a lobby.
@@ -30,7 +31,7 @@ type DeleteLobbyArgs struct {
 // @Failure 403 {object} error "Forbidden"
 // @Failure 500 {object} error "Internal Server Error"
 // @Router /lobby/delete_lobby [delete]
-func DeleteLobby(w http.ResponseWriter, r *http.Request, db *sqlx.DB) error {
+func DeleteLobby(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth.SessionStore) error {
 
 	if r.Method != http.MethodDelete {
 		return errors.New("invalid request; request must be a DELETE request")

--- a/internal/lobby/delete_lobby_test.go
+++ b/internal/lobby/delete_lobby_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"
+	auth "github.com/justinfarrelldev/open-ctp-server/internal/auth"
 )
 
 func TestDeleteLobby_Success(t *testing.T) {
@@ -30,8 +31,13 @@ func TestDeleteLobby_Success(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := DeleteLobby(w, r, sqlxDB)
+		err := DeleteLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -63,8 +69,13 @@ func TestDeleteLobby_InvalidMethod(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := DeleteLobby(w, r, sqlxDB)
+		err := DeleteLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -96,8 +107,13 @@ func TestDeleteLobby_DecodeError(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := DeleteLobby(w, r, sqlxDB)
+		err := DeleteLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -129,8 +145,13 @@ func TestDeleteLobby_LobbyIDNotSpecified(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := DeleteLobby(w, r, sqlxDB)
+		err := DeleteLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
@@ -168,8 +189,13 @@ func TestDeleteLobby_NoRowsAffected(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := DeleteLobby(w, r, sqlxDB)
+		err := DeleteLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/internal/lobby/get_lobby.go
+++ b/internal/lobby/get_lobby.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/justinfarrelldev/open-ctp-server/internal/auth"
 )
 
 // GetLobbyArgs represents the expected structure of the request body for getting a lobby.
@@ -32,7 +33,7 @@ type GetLobbyArgs struct {
 // @Failure 403 {object} error "Forbidden"
 // @Failure 500 {object} error "Internal Server Error"
 // @Router /lobby/get_lobby [get]
-func GetLobby(w http.ResponseWriter, r *http.Request, db *sqlx.DB) error {
+func GetLobby(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth.SessionStore) error {
 
 	if r.Method != "GET" {
 		return errors.New("invalid request; request must be a GET request")

--- a/internal/lobby/get_lobby_test.go
+++ b/internal/lobby/get_lobby_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"
+	auth "github.com/justinfarrelldev/open-ctp-server/internal/auth"
 )
 
 func TestGetLobby_Success(t *testing.T) {
@@ -40,8 +41,13 @@ func TestGetLobby_Success(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := GetLobby(w, r, sqlxDB)
+		err := GetLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -79,8 +85,13 @@ func TestGetLobby_NotFound(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := GetLobby(w, r, sqlxDB)
+		err := GetLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -112,8 +123,13 @@ func TestGetLobby_InvalidMethod(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := GetLobby(w, r, sqlxDB)
+		err := GetLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -145,8 +161,13 @@ func TestGetLobby_DecodeError(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := GetLobby(w, r, sqlxDB)
+		err := GetLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/internal/lobby/get_lobby_test.go
+++ b/internal/lobby/get_lobby_test.go
@@ -21,18 +21,19 @@ func TestGetLobby_Success(t *testing.T) {
 
 	lobbyID := int64(1)
 	expectedLobby := Lobby{
-		ID:        lobbyID,
-		Name:      "Test Lobby",
-		OwnerName: "Owner",
-		IsClosed:  false,
-		IsMuted:   false,
-		IsPublic:  true,
+		ID:             lobbyID,
+		Name:           "Test Lobby",
+		OwnerName:      "Owner",
+		OwnerAccountId: "1",
+		IsClosed:       false,
+		IsMuted:        false,
+		IsPublic:       true,
 	}
 
 	mock.ExpectQuery("SELECT id, name, owner_name, is_closed, is_muted, is_public FROM lobby WHERE id = \\$1").
 		WithArgs(lobbyID).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "owner_name", "is_closed", "is_muted", "is_public"}).
-			AddRow(expectedLobby.ID, expectedLobby.Name, expectedLobby.OwnerName, expectedLobby.IsClosed, expectedLobby.IsMuted, expectedLobby.IsPublic))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "owner_name", "owner_account_id", "is_closed", "is_muted", "is_public"}).
+			AddRow(expectedLobby.ID, expectedLobby.Name, expectedLobby.OwnerName, expectedLobby.OwnerAccountId, expectedLobby.IsClosed, expectedLobby.IsMuted, expectedLobby.IsPublic))
 
 	req, err := http.NewRequest("GET", "/lobby/get_lobby", strings.NewReader(`{"lobby_id": 1}`))
 	if err != nil {
@@ -59,7 +60,7 @@ func TestGetLobby_Success(t *testing.T) {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
 	}
 
-	expectedResponse := `{"id":1,"name":"Test Lobby","owner_name":"Owner","is_closed":false,"is_muted":false,"is_public":true}`
+	expectedResponse := `{"id":1,"name":"Test Lobby","owner_name":"Owner","owner_account_id":"1","is_closed":false,"is_muted":false,"is_public":true}`
 	if strings.TrimSpace(rr.Body.String()) != expectedResponse {
 		t.Errorf("handler returned unexpected body: got %v want %v", strings.TrimSpace(rr.Body.String()), expectedResponse)
 	}

--- a/internal/lobby/lobby.go
+++ b/internal/lobby/lobby.go
@@ -13,6 +13,9 @@ type Lobby struct {
 	// OwnerName is the name of the lobby owner.
 	OwnerName string `json:"owner_name" db:"owner_name"`
 
+	// OwnerAccountId is the account ID of the lobby owner.
+	OwnerAccountId int64 `json:"owner_account_id" db:"owner_account_id"`
+
 	// IsClosed indicates if the lobby is closed.
 	IsClosed bool `json:"is_closed" db:"is_closed"`
 
@@ -35,6 +38,9 @@ type LobbyParam struct {
 
 	// OwnerName is the name of the lobby owner.
 	OwnerName *string `json:"owner_name,omitempty" db:"owner_name"`
+
+	// OwnerAccountId is the account ID of the lobby owner.
+	OwnerAccountId *int64 `json:"owner_account_id,omitempty" db:"owner_account_id"`
 
 	// IsClosed indicates if the lobby is closed.
 	IsClosed *bool `json:"is_closed,omitempty" db:"is_closed"`

--- a/internal/lobby/lobby.go
+++ b/internal/lobby/lobby.go
@@ -14,7 +14,7 @@ type Lobby struct {
 	OwnerName string `json:"owner_name" db:"owner_name"`
 
 	// OwnerAccountId is the account ID of the lobby owner.
-	OwnerAccountId int64 `json:"owner_account_id" db:"owner_account_id"`
+	OwnerAccountId string `json:"owner_account_id" db:"owner_account_id"`
 
 	// IsClosed indicates if the lobby is closed.
 	IsClosed bool `json:"is_closed" db:"is_closed"`
@@ -40,7 +40,7 @@ type LobbyParam struct {
 	OwnerName *string `json:"owner_name,omitempty" db:"owner_name"`
 
 	// OwnerAccountId is the account ID of the lobby owner.
-	OwnerAccountId *int64 `json:"owner_account_id,omitempty" db:"owner_account_id"`
+	OwnerAccountId *string `json:"owner_account_id,omitempty" db:"owner_account_id"`
 
 	// IsClosed indicates if the lobby is closed.
 	IsClosed *bool `json:"is_closed,omitempty" db:"is_closed"`

--- a/internal/lobby/lobby_handler.go
+++ b/internal/lobby/lobby_handler.go
@@ -4,34 +4,35 @@ import (
 	"net/http"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/justinfarrelldev/open-ctp-server/internal/auth"
 )
 
-func CreateLobbyHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB) {
-	if err := CreateLobby(w, r, db); err != nil {
+func CreateLobbyHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth.SessionStore) {
+	if err := CreateLobby(w, r, db, store); err != nil {
 		// Handle the error, e.g., log it and send an appropriate response to the client
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 }
 
-func GetLobbyHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB) {
-	if err := GetLobby(w, r, db); err != nil {
+func GetLobbyHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth.SessionStore) {
+	if err := GetLobby(w, r, db, store); err != nil {
 		// Handle the error, e.g., log it and send an appropriate response to the client
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 }
 
-func UpdateLobbyHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB) {
-	if err := UpdateLobby(w, r, db); err != nil {
+func UpdateLobbyHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth.SessionStore) {
+	if err := UpdateLobby(w, r, db, store); err != nil {
 		// Handle the error, e.g., log it and send an appropriate response to the client
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 }
 
-func DeleteLobbyHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB) {
-	if err := DeleteLobby(w, r, db); err != nil {
+func DeleteLobbyHandler(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth.SessionStore) {
+	if err := DeleteLobby(w, r, db, store); err != nil {
 		// Handle the error, e.g., log it and send an appropriate response to the client
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/lobby/lobby_handler_test.go
+++ b/internal/lobby/lobby_handler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"
+	"github.com/justinfarrelldev/open-ctp-server/internal/auth"
 )
 
 func TestCreateLobbyHandler_Success(t *testing.T) {
@@ -37,8 +38,13 @@ func TestCreateLobbyHandler_Success(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		CreateLobbyHandler(w, r, sqlxDB)
+		CreateLobbyHandler(w, r, sqlxDB, mockStore)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -62,8 +68,13 @@ func TestCreateLobbyHandler_InvalidMethod(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		CreateLobbyHandler(w, r, sqlxDB)
+		CreateLobbyHandler(w, r, sqlxDB, mockStore)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -92,8 +103,13 @@ func TestCreateLobbyHandler_DecodeError(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		CreateLobbyHandler(w, r, sqlxDB)
+		CreateLobbyHandler(w, r, sqlxDB, mockStore)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -122,8 +138,13 @@ func TestCreateLobbyHandler_PasswordTooShort(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		CreateLobbyHandler(w, r, sqlxDB)
+		CreateLobbyHandler(w, r, sqlxDB, mockStore)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -152,8 +173,13 @@ func TestCreateLobbyHandler_PasswordRequired(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		CreateLobbyHandler(w, r, sqlxDB)
+		CreateLobbyHandler(w, r, sqlxDB, mockStore)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -196,8 +222,13 @@ func TestGetLobbyHandler_Success(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		GetLobbyHandler(w, r, sqlxDB)
+		GetLobbyHandler(w, r, sqlxDB, mockStore)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -221,8 +252,13 @@ func TestGetLobbyHandler_InvalidMethod(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		GetLobbyHandler(w, r, sqlxDB)
+		GetLobbyHandler(w, r, sqlxDB, mockStore)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -251,8 +287,13 @@ func TestGetLobbyHandler_DecodeError(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		GetLobbyHandler(w, r, sqlxDB)
+		GetLobbyHandler(w, r, sqlxDB, mockStore)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -266,7 +307,6 @@ func TestGetLobbyHandler_DecodeError(t *testing.T) {
 		t.Errorf("handler returned unexpected body: got %v want %v", strings.TrimSpace(rr.Body.String()), expectedError)
 	}
 }
-
 func TestGetLobbyHandler_LobbyNotFound(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -285,8 +325,13 @@ func TestGetLobbyHandler_LobbyNotFound(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		GetLobbyHandler(w, r, sqlxDB)
+		GetLobbyHandler(w, r, sqlxDB, mockStore)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -319,8 +364,13 @@ func TestDeleteLobbyHandler_Success(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		DeleteLobbyHandler(w, r, sqlxDB)
+		DeleteLobbyHandler(w, r, sqlxDB, mockStore)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -349,8 +399,13 @@ func TestDeleteLobbyHandler_InvalidMethod(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		DeleteLobbyHandler(w, r, sqlxDB)
+		DeleteLobbyHandler(w, r, sqlxDB, mockStore)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -379,8 +434,13 @@ func TestDeleteLobbyHandler_DecodeError(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		DeleteLobbyHandler(w, r, sqlxDB)
+		DeleteLobbyHandler(w, r, sqlxDB, mockStore)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -413,8 +473,13 @@ func TestDeleteLobbyHandler_LobbyNotFound(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		DeleteLobbyHandler(w, r, sqlxDB)
+		DeleteLobbyHandler(w, r, sqlxDB, mockStore)
 	})
 
 	handler.ServeHTTP(rr, req)
@@ -443,8 +508,13 @@ func TestDeleteLobbyHandler_LobbyIdRequired(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		DeleteLobbyHandler(w, r, sqlxDB)
+		DeleteLobbyHandler(w, r, sqlxDB, mockStore)
 	})
 
 	handler.ServeHTTP(rr, req)

--- a/internal/lobby/lobby_handler_test.go
+++ b/internal/lobby/lobby_handler_test.go
@@ -2,6 +2,8 @@ package lobby
 
 import (
 	"database/sql"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -20,18 +22,25 @@ func TestCreateLobbyHandler_Success(t *testing.T) {
 	defer db.Close()
 
 	lobby := Lobby{
-		Name:      "Test Lobby",
-		OwnerName: "Owner",
-		IsClosed:  false,
-		IsMuted:   false,
-		IsPublic:  true,
+		Name:           "Test Lobby",
+		OwnerName:      "Owner",
+		OwnerAccountId: "1",
+		IsClosed:       false,
+		IsMuted:        false,
+		IsPublic:       true,
 	}
 
-	mock.ExpectQuery("INSERT INTO lobby \\(name, owner_name, is_closed, is_muted, is_public\\) VALUES \\(\\$1, \\$2, \\$3, \\$4, \\$5\\)").
-		WithArgs(lobby.Name, lobby.OwnerName, lobby.IsClosed, lobby.IsMuted, lobby.IsPublic).
+	mock.ExpectQuery("INSERT INTO lobby \\(name, owner_name, owner_account_id, is_closed, is_muted, is_public\\) VALUES \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6\\)").
+		WithArgs(lobby.Name, lobby.OwnerName, lobby.OwnerAccountId, lobby.IsClosed, lobby.IsMuted, lobby.IsPublic).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
 
-	req, err := http.NewRequest("POST", "/lobby/create_lobby", strings.NewReader(`{"lobby": {"name": "Test Lobby", "owner_name": "Owner", "is_closed": false, "is_muted": false, "is_public": true}, "password": "password123"}`))
+	lobbyBytes, err := json.Marshal(lobby)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lobbyJSON := fmt.Sprintf(`{"lobby": %s, "password": "password123"}`, string(lobbyBytes))
+
+	req, err := http.NewRequest("POST", "/lobby/create_lobby", strings.NewReader(lobbyJSON))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/lobby/lobby_handler_test.go
+++ b/internal/lobby/lobby_handler_test.go
@@ -140,7 +140,22 @@ func TestCreateLobbyHandler_PasswordTooShort(t *testing.T) {
 	}
 	defer db.Close()
 
-	req, err := http.NewRequest("POST", "/lobby/create_lobby", strings.NewReader(`{"lobby": {"name": "Test Lobby", "owner_name": "Owner", "is_closed": false, "is_muted": false, "is_public": true}, "password": "123"}`))
+	lobby := Lobby{
+		Name:           "Test Lobby",
+		OwnerName:      "Owner",
+		OwnerAccountId: "1",
+		IsClosed:       false,
+		IsMuted:        false,
+		IsPublic:       true,
+	}
+
+	lobbyBytes, err := json.Marshal(lobby)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lobbyJSON := fmt.Sprintf(`{"lobby": %s, "password": "123"}`, string(lobbyBytes))
+
+	req, err := http.NewRequest("POST", "/lobby/create_lobby", strings.NewReader(lobbyJSON))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/lobby/update_lobby.go
+++ b/internal/lobby/update_lobby.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/justinfarrelldev/open-ctp-server/internal/auth"
 )
 
 // UpdateLobbyArgs represents the expected structure of the request body for updating a lobby.
@@ -32,7 +33,7 @@ type UpdateLobbyArgs struct {
 // @Failure 400 {string} string "lobby_id must be specified"
 // @Failure 500 {string} string "an error occurred while decoding the request body: <error message>"
 // @Router /lobby/update_lobby [put]
-func UpdateLobby(w http.ResponseWriter, r *http.Request, db *sqlx.DB) error {
+func UpdateLobby(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth.SessionStore) error {
 
 	if r.Method != http.MethodPut {
 		return errors.New("invalid request; request must be a PUT request")

--- a/internal/lobby/update_lobby_test.go
+++ b/internal/lobby/update_lobby_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"
+	auth "github.com/justinfarrelldev/open-ctp-server/internal/auth"
 )
 
 func TestUpdateLobby_InvalidMethod(t *testing.T) {
@@ -26,8 +27,12 @@ func TestUpdateLobby_InvalidMethod(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := UpdateLobby(w, r, sqlxDB)
+		err := UpdateLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -59,8 +64,12 @@ func TestUpdateLobby_DecodeError(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := UpdateLobby(w, r, sqlxDB)
+		err := UpdateLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -100,8 +109,12 @@ func TestUpdateLobby_MissingLobbyID(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := UpdateLobby(w, r, sqlxDB)
+		err := UpdateLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -139,8 +152,12 @@ func TestUpdateLobby_MissingLobby(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := UpdateLobby(w, r, sqlxDB)
+		err := UpdateLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -191,13 +208,16 @@ func TestUpdateLobby_Success(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	mockStore := &auth.SessionStore{
+		DB: sqlxDB,
+	}
 
 	mock.ExpectExec("UPDATE lobby SET name = \\$1, owner_name = \\$2, is_closed = \\$3, is_muted = \\$4, is_public = \\$5 WHERE id = \\$6").
 		WithArgs(name, ownerName, isClosed, isMuted, isPublic, lobbyID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := UpdateLobby(w, r, sqlxDB)
+		err := UpdateLobby(w, r, sqlxDB, mockStore)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	account "github.com/justinfarrelldev/open-ctp-server/internal/account"
+	auth "github.com/justinfarrelldev/open-ctp-server/internal/auth"
 	game "github.com/justinfarrelldev/open-ctp-server/internal/game"
 	health "github.com/justinfarrelldev/open-ctp-server/internal/health"
 	lobby "github.com/justinfarrelldev/open-ctp-server/internal/lobby"
@@ -102,6 +103,8 @@ func main() {
 
 	fmt.Println("opened connection to database successfully")
 
+	sessionStore := auth.NewSessionStore(db)
+
 	// Handlers
 	mux := http.NewServeMux()
 
@@ -110,7 +113,7 @@ func main() {
 	}))
 
 	mux.Handle("/account/create_account", tollbooth.LimitFuncHandler(tollboothLimiterMinute, func(w http.ResponseWriter, r *http.Request) {
-		account.CreateAccountHandler(w, r, db)
+		account.CreateAccountHandler(w, r, db, sessionStore)
 	}))
 
 	mux.Handle("/account/get_account", tollbooth.LimitFuncHandler(tollboothLimiter, func(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func main() {
 	}))
 
 	mux.Handle("/account/get_account", tollbooth.LimitFuncHandler(tollboothLimiter, func(w http.ResponseWriter, r *http.Request) {
-		account.GetAccountHandler(w, r, db)
+		account.GetAccountHandler(w, r, db, sessionStore)
 	}))
 
 	mux.Handle("/account/update_account", tollbooth.LimitFuncHandler(tollboothLimiter, func(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -125,19 +125,19 @@ func main() {
 	}))
 
 	mux.Handle("/lobby/create_lobby", tollbooth.LimitFuncHandler(tollboothLimiterMinute, func(w http.ResponseWriter, r *http.Request) {
-		lobby.CreateLobbyHandler(w, r, db)
+		lobby.CreateLobbyHandler(w, r, db, sessionStore)
 	}))
 
 	mux.Handle("/lobby/get_lobby", tollbooth.LimitFuncHandler(tollboothLimiter, func(w http.ResponseWriter, r *http.Request) {
-		lobby.GetLobbyHandler(w, r, db)
+		lobby.GetLobbyHandler(w, r, db, sessionStore)
 	}))
 
 	mux.Handle("/lobby/update_lobby", tollbooth.LimitFuncHandler(tollboothLimiter, func(w http.ResponseWriter, r *http.Request) {
-		lobby.UpdateLobbyHandler(w, r, db)
+		lobby.UpdateLobbyHandler(w, r, db, sessionStore)
 	}))
 
 	mux.Handle("/lobby/delete_lobby", tollbooth.LimitFuncHandler(tollboothLimiter, func(w http.ResponseWriter, r *http.Request) {
-		lobby.DeleteLobbyHandler(w, r, db)
+		lobby.DeleteLobbyHandler(w, r, db, sessionStore)
 	}))
 
 	mux.Handle("/health", tollbooth.LimitFuncHandler(tollboothLimiterHealth, health.HealthCheckHandler))

--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func main() {
 	}))
 
 	mux.Handle("/account/update_account", tollbooth.LimitFuncHandler(tollboothLimiter, func(w http.ResponseWriter, r *http.Request) {
-		account.UpdateAccountHandler(w, r, db)
+		account.UpdateAccountHandler(w, r, db, sessionStore)
 	}))
 
 	mux.Handle("/lobby/create_lobby", tollbooth.LimitFuncHandler(tollboothLimiterMinute, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This has been a long time coming, but this feature will add the feature that only users that are logged into their account can change their respective account (or alter the lobbies they made / are given permission to). 

This is very necessary for the game server to function properly and will take quite a bit of work. 