### PR TITLE
[major] Add justinfarrelldev to VSCode settings for extensions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
     "healthcheck",
     "healthgrpc",
     "jmoiron",
+    "justinfarrelldev",
     "Ninjaboy",
     "proto",
     "Protobuf",


### PR DESCRIPTION
This is mostly for the version bump, but initially was because there are a bunch of words showing in CSpell as "Unknown". That said, I think it's a bug now - the words are all under my /home/user/Go, which is nowhere near my workspace.