### PR TITLE
Add session refresh functionality with tests

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -498,6 +498,42 @@ const docTemplate = `{
                 }
             }
         },
+        "/sessions/refresh/{account_id}": {
+            "put": {
+                "description": "Refresh the session token for a given account ID. Extends the expiration by 12 hours.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Refresh a session",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Account ID",
+                        "name": "account_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/auth.Session"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {}
+                    }
+                }
+            }
+        },
         "/sessions/{id}": {
             "get": {
                 "description": "Get a session by its ID",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -489,6 +489,42 @@
                 }
             }
         },
+        "/sessions/refresh/{account_id}": {
+            "put": {
+                "description": "Refresh the session token for a given account ID. Extends the expiration by 12 hours.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Refresh a session",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Account ID",
+                        "name": "account_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/auth.Session"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {}
+                    }
+                }
+            }
+        },
         "/sessions/{id}": {
             "get": {
                 "description": "Get a session by its ID",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -595,4 +595,29 @@ paths:
       summary: Get a session
       tags:
       - sessions
+  /sessions/refresh/{account_id}:
+    put:
+      consumes:
+      - application/json
+      description: Refresh the session token for a given account ID. Extends the expiration
+        by 12 hours.
+      parameters:
+      - description: Account ID
+        in: path
+        name: account_id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/auth.Session'
+        "404":
+          description: Not Found
+          schema: {}
+      summary: Refresh a session
+      tags:
+      - sessions
 swagger: "2.0"

--- a/internal/account/get_account.go
+++ b/internal/account/get_account.go
@@ -80,6 +80,13 @@ func GetAccount(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth
 		return errors.New("session has expired")
 	}
 
+	// Refresh the session
+	_, err = store.RefreshSession(session.AccountID)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return errors.New("an error occurred while refreshing the session: " + err.Error())
+	}
+
 	var (
 		name            string
 		info            string


### PR DESCRIPTION
This PR is to add functionality that ensures that when a player makes any form of interaction, it refreshes the time it will take for them to time out of their session.

For example, when a player first initializes a session, they have 12 hours before they are logged out. 

If they do not interact further, they will no longer be logged in when the 12 hours is up. 

However, let's say that they update their account information an hour after their session. This would mean the timer would be reset to 12 hours, meaning that the player will have had 13 hours logged into the server. This functionality would prevent someone from being logged out in the middle of a match.

The "refreshing the session" portion of the above is what this PR is meant to fulfill.