### PR TITLE
Refactor session ID handling to use int64 instead of string

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -187,10 +187,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successfully updated account!",
-                        "schema": {
-                            "type": "string"
-                        }
+                        "description": "Successfully updated account!"
                     },
                     "400": {
                         "description": "account_id must be specified",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -46,7 +46,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Account successfully created",
                         "schema": {
-                            "type": "string"
+                            "type": "integer"
                         }
                     },
                     "400": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -513,7 +513,7 @@ const docTemplate = `{
                 "summary": "Get a session",
                 "parameters": [
                     {
-                        "type": "string",
+                        "type": "integer",
                         "description": "Session ID",
                         "name": "id",
                         "in": "path",
@@ -717,7 +717,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "id": {
-                    "type": "string"
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -37,7 +37,7 @@
                     "201": {
                         "description": "Account successfully created",
                         "schema": {
-                            "type": "string"
+                            "type": "integer"
                         }
                     },
                     "400": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -504,7 +504,7 @@
                 "summary": "Get a session",
                 "parameters": [
                     {
-                        "type": "string",
+                        "type": "integer",
                         "description": "Session ID",
                         "name": "id",
                         "in": "path",
@@ -708,7 +708,7 @@
                     "type": "string"
                 },
                 "id": {
-                    "type": "string"
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -178,10 +178,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successfully updated account!",
-                        "schema": {
-                            "type": "string"
-                        }
+                        "description": "Successfully updated account!"
                     },
                     "400": {
                         "description": "account_id must be specified",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -244,7 +244,7 @@ paths:
         "201":
           description: Account successfully created
           schema:
-            type: string
+            type: integer
         "400":
           description: Bad Request
           schema: {}

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -340,8 +340,6 @@ paths:
       responses:
         "200":
           description: Successfully updated account!
-          schema:
-            type: string
         "400":
           description: account_id must be specified
           schema:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -106,7 +106,7 @@ definitions:
       expires_at:
         type: string
       id:
-        type: string
+        type: integer
     type: object
   game.CreateGameArgs:
     description: Structure for the game creation request payload.
@@ -581,7 +581,7 @@ paths:
         in: path
         name: id
         required: true
-        type: string
+        type: integer
       produces:
       - application/json
       responses:

--- a/internal/account/create_account.go
+++ b/internal/account/create_account.go
@@ -56,7 +56,7 @@ func isEmailValid(email string, db *sqlx.DB) (bool, error) {
 // @Accept json
 // @Produce json
 // @Param body body CreateAccountArgs true "account creation request body"
-// @Success 201 {string} string "Account successfully created"
+// @Success 201 {integer} int64 "Account successfully created"
 // @Failure 400 {object} error "Bad Request"
 // @Failure 403 {object} error "Forbidden"
 // @Failure 500 {object} error "Internal Server Error"

--- a/internal/account/create_account.go
+++ b/internal/account/create_account.go
@@ -61,7 +61,7 @@ func isEmailValid(email string, db *sqlx.DB) (bool, error) {
 // @Failure 403 {object} error "Forbidden"
 // @Failure 500 {object} error "Internal Server Error"
 // @Router /account/create_account [post]
-func CreateAccount(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth.SessionStore) (*string, error) {
+func CreateAccount(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth.SessionStore) (*int64, error) {
 
 	if r.Method != "POST" {
 		w.WriteHeader(http.StatusBadRequest)

--- a/internal/account/delete_account.go
+++ b/internal/account/delete_account.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/justinfarrelldev/open-ctp-server/internal/auth"
@@ -63,7 +62,7 @@ func DeleteAccount(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *a
 
 	fmt.Println("args: ", *args.AccountId)
 
-	session, err := store.GetSession(strconv.FormatInt(*args.SessionId, 10))
+	session, err := store.GetSession(*args.SessionId)
 
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/account/delete_account_test.go
+++ b/internal/account/delete_account_test.go
@@ -208,7 +208,7 @@ func TestDeleteAccount_SessionNotFound(t *testing.T) {
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM sessions WHERE id = $1")).
-		WithArgs(fmt.Sprint(sessionID)).
+		WithArgs(sessionID).
 		WillReturnRows(sqlmock.NewRows(nil))
 
 	mockStore := &auth.SessionStore{
@@ -263,7 +263,7 @@ func TestDeleteAccount_SessionExpired(t *testing.T) {
 	expiresAt := time.Now().Add(-1 * time.Hour)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM sessions WHERE id = $1")).
-		WithArgs(fmt.Sprintf("%d", sessionID)).
+		WithArgs(sessionID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "account_id", "created_at", "expires_at"}).
 			AddRow(sessionID, accountID, createdAt, expiresAt))
 
@@ -319,7 +319,7 @@ func TestDeleteAccount_Success(t *testing.T) {
 	expiresAt := time.Now().Add(6 * time.Hour)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM sessions WHERE id = $1")).
-		WithArgs(fmt.Sprintf("%d", sessionID)).
+		WithArgs(sessionID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "account_id", "created_at", "expires_at"}).
 			AddRow(sessionID, accountID, createdAt, expiresAt))
 
@@ -384,7 +384,7 @@ func TestDeleteAccount_NoAccountExists(t *testing.T) {
 	expiresAt := time.Now().Add(6 * time.Hour)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM sessions WHERE id = $1")).
-		WithArgs(fmt.Sprintf("%d", sessionID)).
+		WithArgs(sessionID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "account_id", "created_at", "expires_at"}).
 			AddRow(sessionID, accountID, createdAt, expiresAt))
 

--- a/internal/account/get_account.go
+++ b/internal/account/get_account.go
@@ -64,7 +64,7 @@ func GetAccount(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *auth
 		return errors.New("invalid session_id")
 	}
 
-	session, err := store.GetSession(strconv.FormatInt(sessionId, 10))
+	session, err := store.GetSession(sessionId)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return errors.New("an error occurred while retrieving the session: " + err.Error())

--- a/internal/account/get_account_test.go
+++ b/internal/account/get_account_test.go
@@ -23,7 +23,7 @@ func TestGetAccount_Success(t *testing.T) {
 	defer db.Close()
 
 	accountID := int64(1)
-	sessionID := "1"
+	var sessionID int64 = 1
 
 	expectedAccount := Account{
 		Name:            "John Doe",
@@ -84,7 +84,7 @@ func TestGetAccount_NotFound(t *testing.T) {
 	defer db.Close()
 
 	accountID := int64(1)
-	sessionID := "1"
+	var sessionID int64 = 1
 
 	createdAt := time.Now()
 	expiresAt := time.Now().Add(6 * time.Hour)

--- a/internal/account/update_account.go
+++ b/internal/account/update_account.go
@@ -34,7 +34,7 @@ type UpdateAccountArgs struct {
 // @Accept json
 // @Produce json
 // @Param body body UpdateAccountArgs true "account update request body"
-// @Success 200 {string} string "Successfully updated account!"
+// @Success 200 {object} nil "Successfully updated account!"
 // @Failure 400 {string} string "account_id must be specified"
 // @Failure 500 {string} string "an error occurred while decoding the request body: <error message>"
 // @Router /account/update_account [put]

--- a/internal/account/update_account.go
+++ b/internal/account/update_account.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
-	"strconv"
 
 	"github.com/jmoiron/sqlx"
 	auth "github.com/justinfarrelldev/open-ctp-server/internal/auth"
@@ -66,7 +65,7 @@ func UpdateAccount(w http.ResponseWriter, r *http.Request, db *sqlx.DB, store *a
 		return errors.New("a valid session_id must be specified")
 	}
 
-	session, err := store.GetSession(strconv.FormatInt(*args.SessionId, 10))
+	session, err := store.GetSession(*args.SessionId)
 
 	if err != nil {
 

--- a/internal/account/update_account_test.go
+++ b/internal/account/update_account_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -145,7 +144,7 @@ func TestUpdateAccount_Success(t *testing.T) {
 	defer db.Close()
 
 	accountID := int64(1)
-	sessionID := "1"
+	var sessionID int64 = 1
 	password := "password123"
 	name := "Updated Name"
 	info := "Updated Info"
@@ -153,7 +152,6 @@ func TestUpdateAccount_Success(t *testing.T) {
 	email := "updated@example.com"
 	experienceLevel := 2
 
-	sessionIDInt, err := strconv.ParseInt(sessionID, 10, 64)
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when converting sessionID to int64", err)
 	}
@@ -168,7 +166,7 @@ func TestUpdateAccount_Success(t *testing.T) {
 			Email:           &email,
 			ExperienceLevel: (*ExperienceLevel)(&experienceLevel),
 		},
-		SessionId: &sessionIDInt,
+		SessionId: &sessionID,
 	}
 
 	body, _ := json.Marshal(updateArgs)
@@ -240,20 +238,15 @@ func TestUpdateAccount_MissingPassword(t *testing.T) {
 	defer db.Close()
 
 	accountID := int64(1)
-	sessionID := "1"
+	var sessionID int64 = 1
 	name := "Updated Name"
-
-	sessionIDInt, err := strconv.ParseInt(sessionID, 10, 64)
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when converting sessionID to int64", err)
-	}
 
 	updateArgs := UpdateAccountArgs{
 		AccountId: &accountID,
 		Account: &AccountParam{
 			Name: &name,
 		},
-		SessionId: &sessionIDInt,
+		SessionId: &sessionID,
 	}
 
 	body, _ := json.Marshal(updateArgs)
@@ -304,18 +297,13 @@ func TestUpdateAccount_MissingAccount(t *testing.T) {
 	defer db.Close()
 
 	accountID := int64(1)
-	sessionID := "1"
+	var sessionID int64 = 1
 	password := "password123"
-
-	sessionIDInt, err := strconv.ParseInt(sessionID, 10, 64)
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when converting sessionID to int64", err)
-	}
 
 	updateArgs := UpdateAccountArgs{
 		AccountId: &accountID,
 		Password:  &password,
-		SessionId: &sessionIDInt,
+		SessionId: &sessionID,
 	}
 
 	body, _ := json.Marshal(updateArgs)

--- a/internal/auth/sessions_test.go
+++ b/internal/auth/sessions_test.go
@@ -73,7 +73,7 @@ func TestGetSession_Success(t *testing.T) {
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 	store := NewSessionStore(sqlxDB)
 
-	sessionID := "test-session-id"
+	var sessionID int64 = 12345678
 	accountID := 1
 	createdAt := time.Now()
 	expiresAt := createdAt.Add(12 * time.Hour)
@@ -90,7 +90,7 @@ func TestGetSession_Success(t *testing.T) {
 	}
 
 	if session.ID != sessionID {
-		t.Errorf("expected session ID %s, got %s", sessionID, session.ID)
+		t.Errorf("expected session ID %d, got %d", sessionID, session.ID)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -108,7 +108,7 @@ func TestGetSession_NotFound(t *testing.T) {
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 	store := NewSessionStore(sqlxDB)
 
-	sessionID := "non-existent-session-id"
+	var sessionID int64 = 87654321
 	mock.ExpectQuery("SELECT \\* FROM sessions WHERE id = \\$1").
 		WithArgs(sessionID).
 		WillReturnError(sql.ErrNoRows)


### PR DESCRIPTION
This fixes a bug from the C example frontend where the response is this: 

```
an error occurred while creating a session. Please try again at a later time
```

This was due to sessions being generated as strings, but then being treated as integers to Postgres. 